### PR TITLE
Bugfix: Add missed type for separateAfter field

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,6 +44,7 @@ interface OtpInputProps {
   onChange: Function;
   placeholder?: string;
   separator?: Object;
+  separateAfter?: number;
   shouldAutoFocus?: boolean;
   onSubmit?: Function;
   value?: string;


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Add missed type for `separateAfter` field to solve ts error. This field is mentioned in the doc and available to override while using the package.

